### PR TITLE
fix: name prettier worker

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -1,6 +1,7 @@
 {
   "id": "builtin.prettier",
   "name": "Prettier",
+  "workerName": "Prettier",
   "description": "Code formatter using prettier",
   "repository": "https://github.com/lvce-editor/prettier",
   "browser": "dist/prettierMain.js",


### PR DESCRIPTION
Set the isolated extension worker name to Prettier so developer tooling shows a friendly label instead of the extension ID.