### PR TITLE
feature: use workspace prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6172,6 +6172,10 @@
       "resolved": "packages/extension",
       "link": true
     },
+    "node_modules/builtin.prettier-node": {
+      "resolved": "packages/node",
+      "link": true
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -14137,6 +14141,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "packages/node": {
+      "name": "builtin.prettier-node",
+      "version": "0.0.0-dev",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^26.1.1"
       }
     }
   }

--- a/packages/build/src/build-extension.ts
+++ b/packages/build/src/build-extension.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { root } from './root.ts'
 
 const extension = path.join(root, 'packages', 'extension')
+const node = path.join(root, 'packages', 'node')
 const entryPoint = path.join(extension, 'src', 'prettierMain.ts')
 const outdir = path.join(extension, 'dist')
 const outfile = path.join(outdir, 'prettierMain.js')
@@ -23,4 +24,14 @@ await esbuild.build({
   platform: 'browser',
   sourcemap: true,
   target: 'esnext',
+})
+
+await esbuild.build({
+  bundle: true,
+  entryPoints: [path.join(node, 'src', 'prettierNode.ts')],
+  format: 'esm',
+  outdir: path.join(extension, 'node', 'dist'),
+  platform: 'node',
+  sourcemap: true,
+  target: 'node24',
 })

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -4,11 +4,17 @@ import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path, { join } from 'node:path'
 import { rollup } from 'rollup'
+import { build as esbuildBuild } from 'esbuild'
 import esbuild from 'rollup-plugin-esbuild'
 import { copyPrettier } from './copyPrettier.ts'
+import {
+  type ExtensionManifest,
+  withProductionNodeEntryPoint,
+} from './extensionManifest.ts'
 import { root } from './root.ts'
 
 const extension = path.join(root, 'packages', 'extension')
+const node = path.join(root, 'packages', 'node')
 const require = createRequire(import.meta.url)
 const commonjs =
   require('@rollup/plugin-commonjs') as () => import('rollup').Plugin
@@ -24,14 +30,26 @@ fs.copyFileSync(
   join(extension, 'media', 'icon.png'),
   join(root, 'dist', 'media', 'icon.png'),
 )
-fs.copyFileSync(
-  join(extension, 'extension.json'),
+const extensionManifest = JSON.parse(
+  fs.readFileSync(join(extension, 'extension.json'), 'utf8'),
+) as ExtensionManifest
+fs.writeFileSync(
   join(root, 'dist', 'extension.json'),
+  `${JSON.stringify(withProductionNodeEntryPoint(extensionManifest), undefined, 2)}\n`,
 )
 fs.cpSync(join(extension, 'schemas'), join(root, 'dist', 'schemas'), {
   recursive: true,
 })
 copyPrettier(root, join(root, 'dist'))
+
+await esbuildBuild({
+  bundle: true,
+  entryPoints: [join(node, 'src', 'prettierNode.ts')],
+  format: 'esm',
+  outdir: join(root, 'dist', 'node', 'dist'),
+  platform: 'node',
+  target: 'node24',
+})
 
 const bundle = await rollup({
   input: join(extension, 'src', 'prettierMain.ts'),

--- a/packages/build/src/extensionManifest.ts
+++ b/packages/build/src/extensionManifest.ts
@@ -1,0 +1,37 @@
+export interface ExtensionRpc {
+  readonly id: string
+  readonly url: string
+}
+
+export interface ExtensionManifest {
+  readonly rpc: readonly ExtensionRpc[]
+}
+
+const localPrettierRpcId = 'builtin.prettier.local'
+
+export const productionNodeEntryPoint = 'node/dist/prettierNode.js'
+
+export const withProductionNodeEntryPoint = (
+  manifest: Readonly<ExtensionManifest>,
+): ExtensionManifest => {
+  let foundNodeRpc = false
+  const rpc = manifest.rpc.map((entry) => {
+    if (entry.id !== localPrettierRpcId) {
+      return entry
+    }
+    foundNodeRpc = true
+    return {
+      ...entry,
+      url: productionNodeEntryPoint,
+    }
+  })
+  if (!foundNodeRpc) {
+    throw new Error(
+      `Expected extension manifest to include ${localPrettierRpcId}`,
+    )
+  }
+  return {
+    ...manifest,
+    rpc,
+  }
+}

--- a/packages/e2e/src/prettier.local-commonjs.ts
+++ b/packages/e2e/src/prettier.local-commonjs.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-commonjs'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      main: './index.cjs',
+      name: 'prettier',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.cjs`,
+    `module.exports = {
+  version: '3.5.0',
+  format: async () => 'formatted by local commonjs',
+}`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('formatted by local commonjs')
+}

--- a/packages/e2e/src/prettier.local-config-error.ts
+++ b/packages/e2e/src/prettier.local-config-error.ts
@@ -1,0 +1,37 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-config-error'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const resolveConfig = async () => {
+  throw new Error('local prettier config failed')
+}
+export const format = async () => 'unreachable'`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let  x=1')
+}

--- a/packages/e2e/src/prettier.local-esm.ts
+++ b/packages/e2e/src/prettier.local-esm.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-esm'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const format = async () => 'formatted by local esm'`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('formatted by local esm')
+}

--- a/packages/e2e/src/prettier.local-format-error.ts
+++ b/packages/e2e/src/prettier.local-format-error.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-format-error'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const format = async () => {
+  throw new Error('local prettier format failed')
+}`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let  x=1')
+}

--- a/packages/e2e/src/prettier.local-import-error.ts
+++ b/packages/e2e/src/prettier.local-import-error.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-import-error'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `throw new Error('local prettier import failed')`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let x = 1;')
+}

--- a/packages/e2e/src/prettier.local-invalid-module.ts
+++ b/packages/e2e/src/prettier.local-invalid-module.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-invalid-module'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let x = 1;')
+}

--- a/packages/e2e/src/prettier.local-malformed-version.ts
+++ b/packages/e2e/src/prettier.local-malformed-version.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-malformed-version'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = 'latest'
+export const format = async () => 'formatted by invalid prettier'`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let x = 1;')
+}

--- a/packages/e2e/src/prettier.local-nearest-package.ts
+++ b/packages/e2e/src/prettier.local-nearest-package.ts
@@ -1,0 +1,46 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-nearest-package'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const rootPackage = JSON.stringify({
+    exports: './index.js',
+    name: 'prettier',
+    type: 'module',
+  })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    rootPackage,
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const format = async () => 'root local prettier'`,
+  )
+  await FileSystem.mkdir(`${tmpDir}/packages/app/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/packages/app/node_modules/prettier/package.json`,
+    rootPackage,
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/packages/app/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const format = async () => 'nearest local prettier'`,
+  )
+  await FileSystem.mkdir(`${tmpDir}/packages/app/src`)
+  await FileSystem.writeFile(`${tmpDir}/packages/app/src/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/packages/app/src/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('nearest local prettier')
+}

--- a/packages/e2e/src/prettier.local-non-string-result.ts
+++ b/packages/e2e/src/prettier.local-non-string-result.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-non-string-result'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const format = async () => undefined`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let  x=1')
+}

--- a/packages/e2e/src/prettier.local-not-found.ts
+++ b/packages/e2e/src/prettier.local-not-found.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-not-found'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let x = 1;')
+}

--- a/packages/e2e/src/prettier.local-resolve-config.ts
+++ b/packages/e2e/src/prettier.local-resolve-config.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-resolve-config'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '3.6.0'
+export const resolveConfig = async () => ({ marker: 'resolved config' })
+export const format = async (content, options) =>
+  options.marker + ':' + options.filepath.endsWith('/test.js')`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('resolved config:true')
+}

--- a/packages/e2e/src/prettier.local-resolve-config.ts
+++ b/packages/e2e/src/prettier.local-resolve-config.ts
@@ -24,7 +24,7 @@ export const test: Test = async ({
     `export const version = '3.6.0'
 export const resolveConfig = async () => ({ marker: 'resolved config' })
 export const format = async (content, options) =>
-  options.marker + ':' + options.filepath.endsWith('/test.js')`,
+  options.marker + ':' + options.filepath.endsWith('test.js')`,
   )
   await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
   await Main.openUri(`${tmpDir}/test.js`)

--- a/packages/e2e/src/prettier.local-unsupported-version.ts
+++ b/packages/e2e/src/prettier.local-unsupported-version.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-unsupported-version'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '1.19.1'
+export const format = async () => 'formatted by old prettier'`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('let x = 1;')
+}

--- a/packages/e2e/src/prettier.local-version-2.ts
+++ b/packages/e2e/src/prettier.local-version-2.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'prettier.local-version-2'
+
+export const test: Test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.mkdir(`${tmpDir}/node_modules/prettier`)
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/package.json`,
+    JSON.stringify({
+      exports: './index.js',
+      name: 'prettier',
+      type: 'module',
+    }),
+  )
+  await FileSystem.writeFile(
+    `${tmpDir}/node_modules/prettier/index.js`,
+    `export const version = '2.8.8'
+export const format = () => 'formatted by local prettier 2'`,
+  )
+  await FileSystem.writeFile(`${tmpDir}/test.js`, `let  x=1`)
+  await Main.openUri(`${tmpDir}/test.js`)
+
+  await Editor.format()
+
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('formatted by local prettier 2')
+}

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -8,6 +8,14 @@
   "isolated": true,
   "icon": "./media/icon.png",
   "categories": ["Formatters"],
+  "rpc": [
+    {
+      "id": "builtin.prettier.local",
+      "type": "node",
+      "name": "Local Prettier",
+      "url": "../node/src/prettierNode.ts"
+    }
+  ],
   "activation": [
     "onFormatting:css",
     "onFormatting:json",

--- a/packages/extension/src/parts/Format/Format.ts
+++ b/packages/extension/src/parts/Format/Format.ts
@@ -1,5 +1,6 @@
 import type { OffsetBasedEdit } from '../OffsetBasedEdit/OffsetBasedEdit.ts'
 import { FormattingError } from '../FormattingError/FormattingError.ts'
+import * as LocalPrettier from '../LocalPrettier/LocalPrettier.ts'
 import * as MinimizeEdit from '../MinimizeEdit/MinimizeEdit.ts'
 import * as OutputChannel from '../OutputChannel/OutputChannel.ts'
 import * as PluginModule from '../PluginModule/PluginModule.ts'
@@ -36,15 +37,29 @@ export const format = async (
   uri: string,
   content: string,
 ): Promise<OffsetBasedEdit | undefined> => {
-  // console.log({ uri, content })
   if (await PrettierIgnore.isIgnored(uri)) {
     OutputChannel.log(`ignoring ${uri}`)
     return undefined
   }
   OutputChannel.log(`formatting ${uri}`)
-  const fn = getFormatFnSync(uri) || (await getFormatFnAsync(uri))
   try {
-    const formattedText = await fn(content)
+    const localResult = await LocalPrettier.format(uri, content)
+    let formattedText: string
+    if (localResult.status === 'formatted') {
+      OutputChannel.log(
+        `using local Prettier ${localResult.version} from ${localResult.path}`,
+      )
+      const { formattedText: localFormattedText } = localResult
+      formattedText = localFormattedText
+    } else if (localResult.status === 'format-error') {
+      throw new Error(localResult.message)
+    } else {
+      OutputChannel.log(
+        `using bundled Prettier: local Prettier unavailable (${localResult.reason})`,
+      )
+      const fn = getFormatFnSync(uri) || (await getFormatFnAsync(uri))
+      formattedText = await fn(content)
+    }
     const minimizedEdit = MinimizeEdit.minimizeEdit(content, formattedText)
     return minimizedEdit
   } catch (error) {
@@ -53,12 +68,5 @@ export const format = async (
       `Failed to format ${uri}: ${error}`,
     )
     throw enhancedError
-    // if (error instanceof SyntaxError) {
-    //   return {
-    //     error: error.toString(),
-    //   }
-    // }
   }
 }
-
-// format('/test/index.ts', 'let x=2')

--- a/packages/extension/src/parts/LocalPrettier/LocalPrettier.ts
+++ b/packages/extension/src/parts/LocalPrettier/LocalPrettier.ts
@@ -1,0 +1,51 @@
+import { createNodeRpc } from '@lvce-editor/api'
+
+interface LocalPrettierFormattedResult {
+  readonly formattedText: string
+  readonly path: string
+  readonly status: 'formatted'
+  readonly version: string
+}
+
+interface LocalPrettierUnavailableResult {
+  readonly reason: string
+  readonly status: 'unavailable'
+}
+
+interface LocalPrettierFormatErrorResult {
+  readonly message: string
+  readonly status: 'format-error'
+}
+
+export type LocalPrettierResult =
+  | LocalPrettierFormattedResult
+  | LocalPrettierUnavailableResult
+  | LocalPrettierFormatErrorResult
+
+const state: {
+  rpcPromise: ReturnType<typeof createNodeRpc> | undefined
+} = {
+  rpcPromise: undefined,
+}
+
+const getRpc = (): ReturnType<typeof createNodeRpc> => {
+  state.rpcPromise ||= createNodeRpc({
+    id: 'builtin.prettier.local',
+  })
+  return state.rpcPromise
+}
+
+export const format = async (
+  uri: string,
+  content: string,
+): Promise<LocalPrettierResult> => {
+  try {
+    const rpc = await getRpc()
+    return await rpc.invoke('LocalPrettier.format', uri, content)
+  } catch (error) {
+    return {
+      reason: `local Prettier process unavailable: ${error}`,
+      status: 'unavailable',
+    }
+  }
+}

--- a/packages/extension/test/PackageJsonSchema.test.ts
+++ b/packages/extension/test/PackageJsonSchema.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, test } from '@jest/globals'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { describe, expect, test } from '@jest/globals'
 
 const extensionRoot = join(import.meta.dirname, '..')
 
@@ -21,10 +21,10 @@ describe('package.json schema contribution', () => {
     const schema = await readJson(
       join(extensionRoot, 'schemas', 'package.schema.json'),
     )
-    const properties = schema.properties.prettier.properties
+    const { properties } = schema.properties.prettier
     expect(properties.semi).toMatchObject({ type: 'boolean' })
     expect(properties.singleQuote).toMatchObject({ type: 'boolean' })
-    expect(properties.printWidth).toMatchObject({ type: 'integer', minimum: 0 })
+    expect(properties.printWidth).toMatchObject({ minimum: 0, type: 'integer' })
     expect(properties.trailingComma.enum).toEqual(['all', 'es5', 'none'])
   })
 })

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "builtin.prettier-node",
+  "version": "0.0.0-dev",
+  "description": "Node transport for workspace-local Prettier",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/prettierNode.ts",
+  "scripts": {
+    "test": "node --test test/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1"
+  }
+}

--- a/packages/node/src/prettierNode.ts
+++ b/packages/node/src/prettierNode.ts
@@ -48,10 +48,13 @@ const toFilePath = (uri: string): string | undefined => {
   if (uri.startsWith('file:')) {
     return fileURLToPath(uri)
   }
+  if (isAbsolute(uri)) {
+    return uri
+  }
   if (protocolPattern.test(uri)) {
     return undefined
   }
-  return isAbsolute(uri) ? uri : resolve(uri)
+  return resolve(uri)
 }
 
 const getPrettier = (module: unknown): Prettier | undefined => {

--- a/packages/node/src/prettierNode.ts
+++ b/packages/node/src/prettierNode.ts
@@ -1,0 +1,169 @@
+import { createRequire } from 'node:module'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+interface Prettier {
+  readonly format: (
+    content: string,
+    options: Readonly<Record<string, unknown>>,
+  ) => Promise<string> | string
+  readonly resolveConfig?: (
+    filePath: string,
+  ) => Promise<Readonly<Record<string, unknown>> | null>
+  readonly version: string
+}
+
+interface LoadedPrettier {
+  readonly path: string
+  readonly prettier: Prettier
+}
+
+interface FormattedResult {
+  readonly formattedText: string
+  readonly path: string
+  readonly status: 'formatted'
+  readonly version: string
+}
+
+interface UnavailableResult {
+  readonly reason: string
+  readonly status: 'unavailable'
+}
+
+interface FormatErrorResult {
+  readonly message: string
+  readonly status: 'format-error'
+}
+
+type FormatResult = FormattedResult | UnavailableResult | FormatErrorResult
+
+const minimumSupportedMajorVersion = 2
+const protocolPattern = /^[A-Za-z][A-Za-z\d+.-]*:/
+
+const toErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error)
+}
+
+const toFilePath = (uri: string): string | undefined => {
+  if (uri.startsWith('file:')) {
+    return fileURLToPath(uri)
+  }
+  if (protocolPattern.test(uri)) {
+    return undefined
+  }
+  return isAbsolute(uri) ? uri : resolve(uri)
+}
+
+const getPrettier = (module: unknown): Prettier | undefined => {
+  if (!module || typeof module !== 'object') {
+    return undefined
+  }
+  const namespace = module as Record<string, unknown>
+  const candidate =
+    typeof namespace.format === 'function' ? namespace : namespace.default
+  if (!candidate || typeof candidate !== 'object') {
+    return undefined
+  }
+  const prettier = candidate as Partial<Prettier>
+  if (
+    typeof prettier.format !== 'function' ||
+    typeof prettier.version !== 'string'
+  ) {
+    return undefined
+  }
+  return prettier as Prettier
+}
+
+const isSupportedVersion = (version: string): boolean => {
+  const match = /^(\d+)\./.exec(version)
+  return Boolean(match && Number(match[1]) >= minimumSupportedMajorVersion)
+}
+
+const loadPrettier = async (
+  filePath: string,
+): Promise<LoadedPrettier | UnavailableResult> => {
+  let modulePath: string
+  try {
+    const resolverPath = join(dirname(filePath), '.lvce-prettier-resolver.cjs')
+    modulePath = createRequire(resolverPath).resolve('prettier')
+  } catch (error) {
+    return {
+      reason: `not found: ${toErrorMessage(error)}`,
+      status: 'unavailable',
+    }
+  }
+
+  let module: unknown
+  try {
+    module = await import(pathToFileURL(modulePath).href)
+  } catch (error) {
+    return {
+      reason: `failed to load ${modulePath}: ${toErrorMessage(error)}`,
+      status: 'unavailable',
+    }
+  }
+
+  const prettier = getPrettier(module)
+  if (!prettier) {
+    return {
+      reason: `invalid Prettier module at ${modulePath}`,
+      status: 'unavailable',
+    }
+  }
+  if (!isSupportedVersion(prettier.version)) {
+    return {
+      reason: `unsupported Prettier version ${prettier.version}`,
+      status: 'unavailable',
+    }
+  }
+  return {
+    path: modulePath,
+    prettier,
+  }
+}
+
+export const formatLocal = async (
+  uri: string,
+  content: string,
+): Promise<FormatResult> => {
+  const filePath = toFilePath(uri)
+  if (!filePath) {
+    return {
+      reason: `unsupported document URI ${uri}`,
+      status: 'unavailable',
+    }
+  }
+  const loaded = await loadPrettier(filePath)
+  if ('status' in loaded) {
+    return loaded
+  }
+  const { path, prettier } = loaded
+  try {
+    const config = (await prettier.resolveConfig?.(filePath)) || {}
+    const formattedText = await prettier.format(content, {
+      ...config,
+      filepath: filePath,
+    })
+    if (typeof formattedText !== 'string') {
+      return {
+        message: `Local Prettier ${prettier.version} returned a non-string result`,
+        status: 'format-error',
+      }
+    }
+    return {
+      formattedText,
+      path,
+      status: 'formatted',
+      version: prettier.version,
+    }
+  } catch (error) {
+    return {
+      message: `Local Prettier ${prettier.version} failed: ${toErrorMessage(error)}`,
+      status: 'format-error',
+    }
+  }
+}
+
+export const commandMap = {
+  'LocalPrettier.format': formatLocal,
+}

--- a/packages/node/test/prettierNode.test.ts
+++ b/packages/node/test/prettierNode.test.ts
@@ -1,0 +1,283 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { strictEqual, match } from 'node:assert'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, test } from 'node:test'
+import { pathToFileURL } from 'node:url'
+import { formatLocal } from '../src/prettierNode.ts'
+
+const temporaryDirectories: string[] = []
+const defaultPackageJson = {
+  exports: './index.js',
+  name: 'prettier',
+  type: 'module',
+}
+
+const createTemporaryDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), 'lvce-prettier-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+const writeModule = async (
+  root: string,
+  source: string,
+  packageJson: Readonly<Record<string, unknown>> = defaultPackageJson,
+): Promise<void> => {
+  const moduleDirectory = join(root, 'node_modules', 'prettier')
+  await mkdir(moduleDirectory, { recursive: true })
+  await writeFile(
+    join(moduleDirectory, 'package.json'),
+    JSON.stringify(packageJson),
+  )
+  await writeFile(join(moduleDirectory, 'index.js'), source)
+}
+
+afterEach(async () => {
+  const directories = [...temporaryDirectories]
+  temporaryDirectories.length = 0
+  await Promise.all(
+    directories.map((directory) =>
+      rm(directory, { force: true, recursive: true }),
+    ),
+  )
+})
+
+test('returns unavailable when local Prettier is not found', async () => {
+  const root = await createTemporaryDirectory()
+  const result = await formatLocal(join(root, 'test.js'), 'let  x=1')
+
+  strictEqual(result.status, 'unavailable')
+  if (result.status === 'unavailable') {
+    match(result.reason, /not found/)
+  }
+})
+
+test('formats with an ESM local Prettier', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '3.6.0'
+export const format = async () => 'formatted by esm'`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'formatted')
+  if (result.status === 'formatted') {
+    strictEqual(result.formattedText, 'formatted by esm')
+    strictEqual(result.version, '3.6.0')
+  }
+})
+
+test('formats with a CommonJS local Prettier', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `module.exports = {
+  version: '3.5.0',
+  format() {
+    return 'formatted by commonjs'
+  },
+}`,
+    {
+      main: './index.js',
+      name: 'prettier',
+      type: 'commonjs',
+    },
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'formatted')
+  if (result.status === 'formatted') {
+    strictEqual(result.formattedText, 'formatted by commonjs')
+  }
+})
+
+test('passes the resolved config and filepath to local Prettier', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '4.0.0-alpha.10'
+export const resolveConfig = async () => ({ marker: 'from-config' })
+export const format = async (content, options) =>
+  options.marker + ':' + options.filepath + ':' + content`,
+  )
+  const filePath = join(root, 'src', 'test.js')
+
+  const result = await formatLocal(filePath, 'input')
+
+  strictEqual(result.status, 'formatted')
+  if (result.status === 'formatted') {
+    strictEqual(result.formattedText, `from-config:${filePath}:input`)
+  }
+})
+
+test('supports file URIs', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '3.0.0'
+export const format = async () => 'formatted file uri'`,
+  )
+  const uri = pathToFileURL(join(root, 'test.js')).href
+
+  const result = await formatLocal(uri, 'input')
+
+  strictEqual(result.status, 'formatted')
+})
+
+test('does not resolve local modules for non-file URIs', async () => {
+  const result = await formatLocal('memfs:///workspace/test.js', 'input')
+
+  strictEqual(result.status, 'unavailable')
+  if (result.status === 'unavailable') {
+    match(result.reason, /unsupported document URI/)
+  }
+})
+
+test('uses the nearest local Prettier', async () => {
+  const root = await createTemporaryDirectory()
+  const nested = join(root, 'packages', 'app')
+  await writeModule(
+    root,
+    `export const version = '3.0.0'
+export const format = async () => 'root prettier'`,
+  )
+  await writeModule(
+    nested,
+    `export const version = '3.0.0'
+export const format = async () => 'nested prettier'`,
+  )
+
+  const result = await formatLocal(join(nested, 'src', 'test.js'), 'input')
+
+  strictEqual(result.status, 'formatted')
+  if (result.status === 'formatted') {
+    strictEqual(result.formattedText, 'nested prettier')
+  }
+})
+
+test('supports Prettier 2', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '2.8.8'
+export const format = async () => 'old prettier'`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'formatted')
+  if (result.status === 'formatted') {
+    strictEqual(result.formattedText, 'old prettier')
+  }
+})
+
+test('rejects Prettier 1 as unsupported', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '1.19.1'
+export const format = async () => 'unsupported prettier'`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'unavailable')
+  if (result.status === 'unavailable') {
+    match(result.reason, /unsupported Prettier version 1.19.1/)
+  }
+})
+
+test('rejects malformed versions', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = 'latest'
+export const format = async () => 'invalid prettier'`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'unavailable')
+})
+
+test('rejects a module without a format function', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(root, `export const version = '3.0.0'`)
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'unavailable')
+  if (result.status === 'unavailable') {
+    match(result.reason, /invalid Prettier module/)
+  }
+})
+
+test('handles module import errors', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(root, `throw new Error('import failed')`)
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'unavailable')
+  if (result.status === 'unavailable') {
+    match(result.reason, /import failed/)
+  }
+})
+
+test('reports local formatting errors', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '3.0.0'
+export const format = async () => {
+  throw new Error('format failed')
+}`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'format-error')
+  if (result.status === 'format-error') {
+    match(result.message, /format failed/)
+  }
+})
+
+test('reports local configuration errors', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '3.0.0'
+export const resolveConfig = async () => {
+  throw new Error('config failed')
+}
+export const format = async () => 'unreachable'`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'format-error')
+  if (result.status === 'format-error') {
+    match(result.message, /config failed/)
+  }
+})
+
+test('reports non-string formatter results', async () => {
+  const root = await createTemporaryDirectory()
+  await writeModule(
+    root,
+    `export const version = '3.0.0'
+export const format = async () => undefined`,
+  )
+
+  const result = await formatLocal(join(root, 'test.js'), 'input')
+
+  strictEqual(result.status, 'format-error')
+  if (result.status === 'format-error') {
+    match(result.message, /non-string result/)
+  }
+})

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "checkJs": true,
+    "module": "NodeNext",
+    "target": "esnext",
+    "types": ["node"],
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "strict": true,
+    "composite": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "test"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "references": [
     { "path": "./packages/e2e" },
     { "path": "./packages/extension" },
-    { "path": "./packages/build" }
+    { "path": "./packages/build" },
+    { "path": "./packages/node" }
   ]
 }


### PR DESCRIPTION
Use the nearest workspace-local Prettier 2+ installation, including its resolved project configuration. Fall back to bundled Prettier when the local package is missing, invalid, or unsupported, with comprehensive e2e coverage for success and failure paths.