### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/api": "^8.65.0",
+        "@lvce-editor/api": "^8.75.0",
         "@lvce-editor/eslint-config": "^17.6.0",
         "@lvce-editor/server": "0.91.21",
         "@types/node": "^26.1.1",
@@ -2613,12 +2613,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.65.0.tgz",
-      "integrity": "sha512-vXZP7u3TIG9PzP50YUlSqQOqKB1YfKEOs+19m9qazwPHLcU8XFgWEO5XjUnfULlfRHKj8qljFD3naEQCRaPU1Q==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -14167,7 +14168,7 @@
         "ignore": "^7.0.6"
       },
       "devDependencies": {
-        "@lvce-editor/api": "^8.65.0",
+        "@lvce-editor/api": "^8.75.0",
         "@lvce-editor/rpc-registry": "^9.36.0",
         "@types/babel__standalone": "^7.1.9",
         "jest": "^30.4.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Lvce Editor",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/api": "^8.65.0",
+    "@lvce-editor/api": "^8.75.0",
     "@lvce-editor/eslint-config": "^17.6.0",
     "@lvce-editor/server": "0.91.21",
     "@types/node": "^26.1.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -32,7 +32,7 @@
     }
   },
   "devDependencies": {
-    "@lvce-editor/api": "^8.65.0",
+    "@lvce-editor/api": "^8.75.0",
     "@lvce-editor/rpc-registry": "^9.36.0",
     "@types/babel__standalone": "^7.1.9",
     "jest": "^30.4.2",


### PR DESCRIPTION
Update the extension API to 8.75.0 so unused extension commands can be removed from the production bundle. This removes about 40 KB from the extension bundle without changing behavior.